### PR TITLE
Add UPDATE card functionality + fixed DELETE card to correct route and controller files

### DIFF
--- a/client/src/pages/Deck/Deck.css
+++ b/client/src/pages/Deck/Deck.css
@@ -12,6 +12,12 @@
   grid-gap: 16px;
 }
 
+.updateInputBar {
+  width: 80%;
+  margin: 4px;
+  border: 1px solid gray;
+}
+
 /* // Smallest device */
 @media (min-width: 100px) and (max-width: 575px) {
   .cards {

--- a/client/src/pages/Deck/Deck.jsx
+++ b/client/src/pages/Deck/Deck.jsx
@@ -32,7 +32,7 @@ class Deck extends Component {
 
   handleDelete(id) {
     // fetch(`/deck/delete/${id}`, {method: 'DELETE'})
-    axios.delete(`/deck/delete/${id}`, { data: { source: id } })
+    axios.delete(`/card/delete/${id}`, { data: { source: id } })
       .then(deletedNum => {
         console.log(`Successfully deleted ${deletedNum} card[s]`);
         const {deckNumber} = this.props.location.state;

--- a/client/src/pages/Deck/Deck.jsx
+++ b/client/src/pages/Deck/Deck.jsx
@@ -80,7 +80,7 @@ class Deck extends Component {
     // console.log('TESTING: ', v)
     axios.patch(`/card/patch/${cid}`, body)
       .then(updatedNum => {
-        console.log(`Successfully updated ${updatedNum.data} card[s]`);
+        console.log(`Successfully updated ${updatedNum} card[s]`);
         const {deckNumber} = this.props.location.state;
 
         axios.get(`/deck/${deckNumber}`)
@@ -94,9 +94,6 @@ class Deck extends Component {
       .catch((err) => {
         console.log("err: ", err);
       })
-    
-
-      console.log('testin ghere')
   }
 
 

--- a/server/controllers/cardControllers.js
+++ b/server/controllers/cardControllers.js
@@ -19,4 +19,17 @@ cardController.addCard = (req, res, next) => {
     .catch(() => next(new Error('Error in addCard create method')));
 };
 
+
+cardController.deleteCard = (req, res, next) => {
+  const { cardId } = req.params;
+
+  CardModel.deleteOne({ _id: `${cardId}` })
+    .then(data => {
+      res.locals.count = data.n;
+      // console.log('TESTING DATA: ', data);
+      return next();
+    })
+    .catch(err => next(err));
+}
+
 module.exports = cardController;

--- a/server/controllers/cardControllers.js
+++ b/server/controllers/cardControllers.js
@@ -19,4 +19,19 @@ cardController.addCard = (req, res, next) => {
     .catch(() => next(new Error('Error in addCard create method')));
 };
 
+cardController.patchCard = (req, res, next) => {
+  const cid = req.params.cardId;
+  const { term, definition } = req.body;
+  const value = {
+    term: term,
+    definition: definition,
+  };
+
+  CardModel.updateOne({_id: {$eq: cid}}, value)
+    .then(result => {
+      res.locals.patchedCard = result.n;
+    })
+    .catch(err => next(err));
+};
+
 module.exports = cardController;

--- a/server/controllers/cardControllers.js
+++ b/server/controllers/cardControllers.js
@@ -30,6 +30,7 @@ cardController.patchCard = (req, res, next) => {
   CardModel.updateOne({_id: {$eq: cid}}, value)
     .then(result => {
       res.locals.patchedCard = result.n;
+      return next();
     })
     .catch(err => next(err));
 };

--- a/server/controllers/deckControllers.js
+++ b/server/controllers/deckControllers.js
@@ -26,41 +26,4 @@ deckController.readDeckOfCards = (req, res, next) => {
 };
 
 
-
-deckController.deleteCard = (req, res, next) => {
-  const { cardId } = req.params;
-
-  // try {
-  //   const result = CardModel.deleteOne({ _id: `${cardId}` });
-  //   console.log('TESTING', result);
-  //   res.locals.count = result;
-  //   return next()
-  // } catch (err) {
-  //   console.error(err);
-  // }
-
-
-
-  // const query = CardModel.deleteOne({ _id: `${cardId}` });
-  // const promise = query.exec();
-  // promise
-  //   .then(data => {
-  //     res.locals.count = data;
-  //     console.log('TESTING RES.LOCALS.COUNT', res.locals.count);
-  //     next();
-  //   })
-  //   .catch(() => next(new Error('Error in readDeckOfCards read method')));
-
-
-
-  CardModel.deleteOne({ _id: `${cardId}` })
-    .then(data => {
-      res.locals.count = data.n;
-      // console.log('TESTING DATA: ', data);
-      return next();
-    })
-    .catch(err => next(err));
-}
-
-
 module.exports = deckController;

--- a/server/routes/cardRoutes.js
+++ b/server/routes/cardRoutes.js
@@ -12,4 +12,8 @@ cardRouter.post('/', cardController.addCard, (req, res) => {
   res.status(200).send(res.locals.newCard);
 });
 
+cardRouter.patch('/patch/:cardId', cardController.patchCard, (req, res) => {
+  res.status(200).json(res.locals.patchedCard);
+})
+
 module.exports = cardRouter;

--- a/server/routes/cardRoutes.js
+++ b/server/routes/cardRoutes.js
@@ -12,4 +12,12 @@ cardRouter.post('/', cardController.addCard, (req, res) => {
   res.status(200).send(res.locals.newCard);
 });
 
+
+// directs delete request for the selected cardId
+cardRouter.delete('/delete/:cardId', cardController.deleteCard, (req, res) => {
+  res.status(200).json(res.locals.count);
+})
+
+
+
 module.exports = cardRouter;

--- a/server/routes/deckRoutes.js
+++ b/server/routes/deckRoutes.js
@@ -13,9 +13,4 @@ deckRouter.get('/:deckId', deckController.readDeckOfCards, (req, res) => {
 });
 
 
-// directs delete request for the selected cardId
-deckRouter.delete('/delete/:cardId', deckController.deleteCard, (req, res) => {
-  res.status(200).json(res.locals.count);
-})
-
 module.exports = deckRouter;


### PR DESCRIPTION
### CHANGES MADE

- [x] Added additional React state items in Deck.jsx, as well as render items, to account for needed text input boxes and buttons fo update values.
- [x] Added two event handlers to Deck.jsx, one each on the Update Card and Confirmation buttons.
- [x] Added the appropriate routes, controllers, and middleware to enable the Update Card functionality to make changes in the backend MongoDB server.
- [x] Fixed Delete Card backend routes and controllers to the correct Card files (previously Deck).

### REASONS

- This will allow the user to make changes to the created cards on-site instead of having to delete and re-create new ones for a better UX.
- Delete Card changes made for more appropriate organization.

### APPROACH

- The frontend components were changed so that when the Update Card button is pressed, the event handler would render a different UI on the card (controlled by if/else statements). Once the user inputs new values, they can either click "k, w/e" to confirm changes or "wait nvm" to go back to the previous state. Confirmation of changes will send a patch request to the backend and setState back in the front afterwards.
- editMode was added to state to control whether a card was being edited or not at the moment. The value for this key is an array with as many false values as there are cards, and clicking on the "Update Card" button will switch their respective element into true, which will re-render the UI to provide text input bars.